### PR TITLE
removed single line methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,22 +107,19 @@ mind for now.
     FooError = Class.new(StandardError)
     ```
 
-* Avoid single-line methods. Although they are somewhat popular in the
-  wild, there are a few peculiarities about their definition syntax
-  that make their use undesirable. At any rate - there should be no more
-  than one expression in a single-line method.
+* Avoid single-line methods.
 
     ```Ruby
     # bad
     def too_much; something; something_else; end
 
-    # okish - notice that the first ; is required
+    # bad
     def no_braces_method; body end
 
-    # okish - notice that the second ; is optional
+    # bad
     def no_braces_method; body; end
 
-    # okish - valid syntax, but no ; make it kind of hard to read
+    # bad
     def some_method() body end
 
     # good


### PR DESCRIPTION
There's no reason for us to ever define single line methods. Removed
the "okish" references to single line method definitions

@bbean86 @sdrioux 
